### PR TITLE
Add ADR-010 for AdSense script loading fix on GitHub Pages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,6 +16,7 @@ This document serves as an index for all Architecture Decision Records (ADRs) an
 - **[ADR-007-multilingual-blog-support.md](./docs/ADR-007-multilingual-blog-support.md)** - 다국어 블로그 지원 시스템 구현 (한국어/영어/스페인어)
 - **[ADR-008-jekyll-seo-tag-plugin-integration.md](./docs/ADR-008-jekyll-seo-tag-plugin-integration.md)** - Jekyll SEO Tag 플러그인 통합 및 JSON-LD 구조화된 데이터 설정
 - **[ADR-009-multilingual-post-navigation.md](./docs/ADR-009-multilingual-post-navigation.md)** - 다국어 포스트 네비게이션 시스템 구현 (언어별 이전/다음, 관련 포스트 분리)
+- **[ADR-010-adsense-script-loading-fix.md](./docs/ADR-010-adsense-script-loading-fix.md)** - GitHub Pages AdSense 스크립트 로딩 문제 해결 (개행문자 누락 이슈)
 
 ### 📋 ADR Status Overview
 | ADR | Title | Status | Date | Priority |
@@ -29,6 +30,7 @@ This document serves as an index for all Architecture Decision Records (ADRs) an
 | 007 | Multilingual Blog Support | 🚧 In Progress | 2025-09-09 | High |
 | 008 | Jekyll SEO Tag Plugin Integration | ✅ Accepted | 2025-09-15 | High |
 | 009 | Multilingual Post Navigation | ✅ Accepted | 2025-09-16 | High |
+| 010 | AdSense Script Loading Fix | ✅ Accepted | 2025-09-16 | Medium |
 
 ## 🚀 Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,41 @@ description: "Meta description under 160 characters including target keywords an
 - **Tag Performance**: Analyze which tags drive most traffic
 - **Content Updates**: Refresh underperforming posts with new keywords
 
+## ADR (Architecture Decision Record) Workflow
+
+### When to Create ADRs
+Create ADRs for:
+- **Technical decisions** with long-term impact
+- **Problem-solving** that required investigation or debugging
+- **Feature implementations** that affect site architecture
+- **Configuration changes** that might need future reference
+
+### ADR Creation Process
+1. **Create ADR**: Write detailed ADR in `/docs/ADR-XXX-title.md`
+2. **Update ARCHITECTURE.md**: Add reference to new ADR in appropriate section
+3. **Update Status Table**: Add entry to ADR Status Overview table
+4. **Cross-reference**: Link from CLAUDE.md if relevant to future development
+
+### ADR Template Structure
+```markdown
+# ADR-XXX: Title
+
+## Status
+[Accepted/Rejected/Superseded]
+
+## Date
+YYYY-MM-DD
+
+## Context
+[Problem description and background]
+
+## Decision
+[What was decided and how it was implemented]
+
+## Consequences
+[Positive/Negative outcomes and lessons learned]
+```
+
 ## Content Guidelines
 
 When working with content:
@@ -333,5 +368,6 @@ When working with content:
 - **Date Management**: Always include `date` field, optionally add `last_modified_at` for content updates
 - **Multilingual Support**: Add `lang: "ko"` (or "en", "es") for language-aware navigation
 - **⭐ SEO/AEO CRITICAL**: Follow SEO optimization guidelines above for every post
+- **📋 ADR Documentation**: Follow ADR workflow above for technical decisions
 
 **📋 For multilingual post navigation details, see [ADR-009](./docs/ADR-009-multilingual-post-navigation.md)**

--- a/docs/ADR-010-adsense-script-loading-fix.md
+++ b/docs/ADR-010-adsense-script-loading-fix.md
@@ -1,0 +1,72 @@
+# ADR-010: AdSense Script Loading Issue on GitHub Pages
+
+## Status
+Accepted
+
+## Date
+2025-09-16
+
+## Context
+
+Google AdSense 스크립트가 로컬 Jekyll 환경에서는 정상적으로 로드되지만, GitHub Pages에 배포된 사이트에서는 HTML 소스에 포함되지 않는 문제가 발생했다.
+
+### 환경 차이
+- **로컬 환경**: Jekyll 서버에서 AdSense 스크립트 정상 로드
+- **GitHub Pages**: 동일한 코드가 배포되었으나 HTML 소스에서 AdSense 스크립트 누락
+
+### 디버깅 과정
+1. 브라우저 네트워크 탭에서 `adsbygoogle.js` 요청 확인
+2. GitHub Pages 배포된 페이지 HTML 소스 확인
+3. Jekyll 빌드 차이점 분석
+4. `_includes/head/custom.html` 파일 구문 검사
+
+## Problem
+
+`_includes/head/custom.html` 파일이 개행문자(newline) 없이 종료되고 있었다:
+
+```html
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7678791354415268" crossorigin="anonymous"></script>
+```
+(파일 끝에 `\n` 없음)
+
+### 원인 분석
+- Jekyll의 include 파일 처리 시 파일 끝 개행문자 누락으로 인한 파싱 오류
+- 로컬 Jekyll과 GitHub Pages Jekyll 환경의 파싱 방식 차이
+- Liquid 템플릿 처리 과정에서 다음 콘텐츠와의 연결 문제
+
+## Decision
+
+`_includes/head/custom.html` 파일 끝에 개행문자를 추가하여 Jekyll 파싱 오류를 해결한다.
+
+### 해결 방법
+```bash
+echo "" >> _includes/head/custom.html
+```
+
+### 수정 후 파일 구조
+```html
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7678791354415268" crossorigin="anonymous"></script>
+
+```
+(파일 끝에 `\n` 추가됨)
+
+## Consequences
+
+### Positive
+- ✅ GitHub Pages에서 AdSense 스크립트 정상 로드
+- ✅ 로컬과 프로덕션 환경 간 일관성 확보
+- ✅ Jekyll include 파일 파싱 안정성 향상
+
+### Neutral
+- 파일 크기 1바이트 증가 (개행문자)
+- 향후 include 파일 작성 시 개행문자 포함 필요
+
+### Lessons Learned
+- Jekyll include 파일은 반드시 개행문자로 종료해야 함
+- 로컬과 GitHub Pages 환경의 Jekyll 파싱 방식에 미묘한 차이 존재
+- 스크립트 로딩 문제 시 파일 구문 검사 우선 수행 필요
+
+## References
+- Jekyll Include Documentation: https://jekyllrb.com/docs/includes/
+- GitHub Pages Jekyll Version: https://pages.github.com/versions/
+- Google AdSense Implementation Guide


### PR DESCRIPTION
- Documented the issue of missing AdSense script in GitHub Pages due to a newline character omission in the `_includes/head/custom.html` file.
- Updated the architecture documentation to include the new ADR and its status.
- Added a detailed workflow for creating ADRs in CLAUDE.md to standardize documentation practices.